### PR TITLE
fix rhl

### DIFF
--- a/Home.tsx
+++ b/Home.tsx
@@ -1,12 +1,33 @@
 import * as React from 'react';
 
-class Home extends React.Component<{}, {}> {
-  render () {
+export interface state { counter: number; }
+
+class Home extends React.Component<{}, state> {
+  private interval: number;
+
+  constructor(props) {
+    super(props);
+    this.state = { counter: 0 };
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(this.tick.bind(this), 1000);
+  }
+
+  tick() {
+    this.setState({
+      counter: this.state.counter + 1
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
     return (
-      <div>
-        <div>This is Home. Hello Dorothy Parker</div>
-      </div>
-    );
+      <h2>Countaer: {this.state.counter}</h2>
+   );
   }
 }
 

--- a/index.tsx
+++ b/index.tsx
@@ -1,8 +1,24 @@
 import * as React from 'react';
 import { render } from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
 import Home from './Home.tsx';
 
+const rootEl: any = document.getElementById('root');
 render(
-  <Home/>,
-  document.getElementById('root')
+  <AppContainer>
+    <Home/>
+  </AppContainer>,
+  rootEl
 );
+
+if(module.hot) {
+  module.hot.accept('./Home.tsx', () => {
+    const NextHome: any = require<{ default: any }>('./Home.tsx').default;
+    render(
+      <AppContainer>
+        <NextHome />
+      </AppContainer>,
+      rootEl
+    );
+  });
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "express": "^4.14.0",
     "react": "^15.3.1",
+    "react-hot-loader": "^3.0.0-beta.4",
     "react-dom": "^15.3.1"
   },
   "devDependencies": {
-    "react-hot-loader": "^3.0.0-beta.4",
     "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
     "webpack": "^1.13.2",

--- a/react-hot-loader.d.ts
+++ b/react-hot-loader.d.ts
@@ -1,0 +1,4 @@
+declare module "react-hot-loader" {
+  export type AppContainer = any;
+  export var AppContainer: any;
+}

--- a/server.js
+++ b/server.js
@@ -1,21 +1,16 @@
 const express = require('express');
 const config = require('./webpack.config');
 const webpack = require('webpack');
-const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const path = require('path');
 
 var app = express();
 const compiler = webpack(config);
 
-app.use(webpackDevMiddleware(
-    compiler, {
-        hot: true,
-        stats: {
-            colors: true
-        }
-    }
-));
+app.use(require('webpack-dev-middleware')(compiler, {
+  noInfo: true,
+  publicPath: config.output.publicPath
+}));
 app.use(webpackHotMiddleware(compiler));
 
 app.get('/', (req, res) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,14 @@
   "compilerOptions": {
     "outDir": "./build",
     "sourceMap": true,
-    "noImplicitAny": true,
     "module": "commonjs",
     "target": "es5",
     "jsx": "react"
   },
   "files": [
-        "typings/index.d.ts"
+        "typings/index.d.ts",
+        "react-hot-loader.d.ts",
+        "webpack-env.d.ts"
     ],
   "filesGlob": [
     "**/*.ts",

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "react-dom": "registry:npm/react-dom#15.0.1+20160826174104"
+    "react-dom": "registry:npm/react-dom#15.0.1+20160826174104",
+    "webpack": "registry:npm/webpack#1.12.9+20160418172948"
   },
   "globalDependencies": {
     "react": "registry:dt/react#0.14.0+20160829191040"

--- a/webpack-env.d.ts
+++ b/webpack-env.d.ts
@@ -1,0 +1,232 @@
+// Type definitions for webpack 1.12.2 (module API)
+// Project: https://github.com/webpack/webpack
+// Definitions by: use-strict <https://github.com/use-strict>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Webpack module API - variables and global functions available inside modules
+ */
+
+declare namespace __WebpackModuleApi {
+    interface RequireContext {
+        keys(): string[];
+        <T>(id: string): T;
+        resolve(id: string): string;
+    }
+
+    interface RequireFunction {
+        /**
+         * Returns the exports from a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
+         */
+        <T>(path: string): T;
+        /**
+         * Behaves similar to require.ensure, but the callback is called with the exports of each dependency in the paths array. There is no option to provide a chunk name.
+         */
+        (paths: string[], callback: (...modules: any[]) => void): void;
+        /**
+         * Download additional dependencies on demand. The paths array lists modules that should be available. When they are, callback is called. If the callback is a function expression, dependencies in that source part are extracted and also loaded on demand. A single request is fired to the server, except if all modules are already available.
+         *
+         * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
+         */
+        ensure: (paths: string[], callback: (require: <T>(path: string) => T) => void, chunkName?: string) => void;
+        context: (path: string, deep?: boolean, filter?: RegExp) => RequireContext;
+        /**
+         * Returns the module id of a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
+         *
+         * The module id is a number in webpack (in contrast to node.js where it is a string, the filename).
+         */
+        resolve(path: string): number;
+        /**
+         * Like require.resolve, but doesn’t include the module into the bundle. It’s a weak dependency.
+         */
+        resolveWeak(path: string): number;
+        /**
+         * Ensures that the dependency is available, but don’t execute it. This can be use for optimizing the position of a module in the chunks.
+         */
+        include(path: string): void;
+        /**
+         * Multiple requires to the same module result in only one module execution and only one export. Therefore a cache in the runtime exists. Removing values from this cache cause new module execution and a new export. This is only needed in rare cases (for compatibility!).
+         */
+        cache: {
+            [id: string]: any;
+        }
+    }
+
+    interface Module {
+        exports: any;
+        require(id: string): any;
+        id: string;
+        filename: string;
+        loaded: boolean;
+        parent: any;
+        children: any[];
+        hot: Hot;
+    }
+    type ModuleId = string|number;
+
+    interface Hot {
+        /**
+         * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
+         * @param dependencies
+         * @param callback
+         */
+        accept(dependencies: string[], callback: (updatedDependencies: ModuleId[]) => void): void;
+        /**
+         * Accept code updates for the specified dependencies. The callback is called when dependencies were replaced.
+         * @param dependency
+         * @param callback
+         */
+        accept(dependency: string, callback: () => void): void;
+        /**
+         * Accept code updates for this module without notification of parents.
+         * This should only be used if the module doesn’t export anything.
+         * The errHandler can be used to handle errors that occur while loading the updated module.
+         * @param errHandler
+         */
+        accept(errHandler?: (err: Error) => void): void;
+        /**
+         * Do not accept updates for the specified dependencies. If any dependencies is updated, the code update fails with code "decline".
+         */
+        decline(dependencies: string[]): void;
+        /**
+         * Do not accept updates for the specified dependencies. If any dependencies is updated, the code update fails with code "decline".
+         */
+        decline(dependency: string): void;
+        /**
+         * Flag the current module as not update-able. If updated the update code would fail with code "decline".
+         */
+        decline(): void;
+        /**
+         * Add a one time handler, which is executed when the current module code is replaced.
+         * Here you should destroy/remove any persistent resource you have claimed/created.
+         * If you want to transfer state to the new module, add it to data object.
+         * The data will be available at module.hot.data on the new module.
+         * @param callback
+         */
+        dispose<T>(callback: (data: T) => void): void;
+        /**
+         * Add a one time handler, which is executed when the current module code is replaced.
+         * Here you should destroy/remove any persistent resource you have claimed/created.
+         * If you want to transfer state to the new module, add it to data object.
+         * The data will be available at module.hot.data on the new module.
+         * @param callback
+         */
+        addDisposeHandler<T>(callback: (data: T) => void): void;
+        /**
+         * Remove a handler.
+         * This can useful to add a temporary dispose handler. You could i. e. replace code while in the middle of a multi-step async function.
+         * @param callback
+         */
+        removeDisposeHandler<T>(callback: (data: T) => void): void;
+        /**
+         * Throws an exceptions if status() is not idle.
+         * Check all currently loaded modules for updates and apply updates if found.
+         * If no update was found, the callback is called with null.
+         * If autoApply is truthy the callback will be called with all modules that were disposed.
+         * apply() is automatically called with autoApply as options parameter.
+         * If autoApply is not set the callback will be called with all modules that will be disposed on apply().
+         * @param autoApply
+         * @param callback
+         */
+        check(autoApply: boolean, callback: (err: Error, outdatedModules: ModuleId[]) => void): void;
+        /**
+         * Throws an exceptions if status() is not idle.
+         * Check all currently loaded modules for updates and apply updates if found.
+         * If no update was found, the callback is called with null.
+         * The callback will be called with all modules that will be disposed on apply().
+         * @param callback
+         */
+        check(callback: (err: Error, outdatedModules: ModuleId[]) => void): void;
+        /**
+         * If status() != "ready" it throws an error.
+         * Continue the update process.
+         * @param options
+         * @param callback
+         */
+        apply(options: AcceptOptions, callback: (err: Error, outdatedModules: ModuleId[]) => void): void;
+        /**
+         * If status() != "ready" it throws an error.
+         * Continue the update process.
+         * @param callback
+         */
+        apply(callback: (err: Error, outdatedModules: ModuleId[]) => void): void;
+        /**
+         * Return one of idle, check, watch, watch-delay, prepare, ready, dispose, apply, abort or fail.
+         */
+        status(): string;
+        /** Register a callback on status change. */
+        status(callback: (status: string) => void): void;
+        /** Register a callback on status change. */
+        addStatusHandler(callback: (status: string) => void): void;
+        /**
+         * Remove a registered status change handler.
+         * @param callback
+         */
+        removeStatusHandler(callback: (status: string) => void): void;
+
+        active: boolean;
+        data: {};
+    }
+
+    interface AcceptOptions {
+        /**
+         * If true the update process continues even if some modules are not accepted (and would bubble to the entry point).
+         */
+        ignoreUnaccepted?: boolean;
+        /**
+         * Indicates that apply() is automatically called by check function
+         */
+        autoApply?: boolean;
+  }
+}
+
+declare var require: __WebpackModuleApi.RequireFunction;
+
+/**
+ * The resource query of the current module.
+ *
+ * e.g. __resourceQuery === "?test" // Inside "file.js?test"
+ */
+declare var __resourceQuery: string;
+
+/**
+ * Equals the config options output.publicPath.
+ */
+declare var __webpack_public_path__: string;
+
+/**
+ * The raw require function. This expression isn’t parsed by the Parser for dependencies.
+ */
+declare var __webpack_require__: any;
+
+/**
+ * The internal chunk loading function
+ *
+ * @param chunkId The id for the chunk to load.
+ * @param callback A callback function called once the chunk is loaded.
+ */
+declare var __webpack_chunk_load__: (chunkId: any, callback: (require: (id: string) => any) => void) => void;
+
+/**
+ * Access to the internal object of all modules.
+ */
+declare var __webpack_modules__: any[];
+
+/**
+ * Access to the hash of the compilation.
+ *
+ * Only available with the HotModuleReplacementPlugin or the ExtendedAPIPlugin
+ */
+declare var __webpack_hash__: any;
+
+/**
+ * Generates a require function that is not parsed by webpack. Can be used to do cool stuff with a global require function if available.
+ */
+declare var __non_webpack_require__: any;
+
+/**
+ * Equals the config option debug
+ */
+declare var DEBUG: boolean;
+
+declare var module: __WebpackModuleApi.Module;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ var webpack = require('webpack');
 
 module.exports = {
   entry: [
-    'webpack-hot-middleware/client',
     'react-hot-loader/patch',
+    'webpack-hot-middleware/client', // add ?quiet=true to remove warnings
     './index.tsx'
   ],
   output: {
@@ -13,6 +13,7 @@ module.exports = {
     publicPath: ''
   },
   plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],


### PR DESCRIPTION
I had to hack around a bit to get TypeScript to compile, but you can see that `<Home />` hot-reloads without unmounting. I'm not sure at the moment how to remove the annoying console warning about `index.tsx` not reloading after changing `Home.tsx`, but you can add "?quiet=true" to your `webpack-dev-middleware` entry string in the config.
